### PR TITLE
Fix heading typo :-O

### DIFF
--- a/sections/waiver.cform
+++ b/sections/waiver.cform
@@ -1,2 +1,2 @@
     # "Certainly, an antiwaiver provision would militate against a finding of waiver under most circumstances." Gould v. Corinthian Colleges, Inc., 192 Cal.App.4th 1176, 1180 (Cal. Ct. App. 2011) (in dicta).
-    \ Wavier \ The <Parties> will waive parts of this <Agreement>, if at all, only in writing signed by the <Party> waiving.
+    \ Waiver \ The <Parties> will waive parts of this <Agreement>, if at all, only in writing signed by the <Party> waiving.


### PR DESCRIPTION
`Wavier` -> `Waiver`